### PR TITLE
Add ProcesarTareasUseCase tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os, sys
+# Ensure backend package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'backend')))

--- a/tests/test_procesar_tareas_use_case.py
+++ b/tests/test_procesar_tareas_use_case.py
@@ -1,0 +1,73 @@
+import os
+import types
+import sys
+import pytest
+
+# Provide a minimal 'supabase' module so that the repository module can be imported
+supabase_stub = types.ModuleType("supabase")
+supabase_stub.Client = object  # placeholder type
+sys.modules.setdefault("supabase", supabase_stub)
+
+from app.domain.use_cases.procesar_tareas import ProcesarTareasUseCase
+from app.domain.entities.constants import REQUIRED_COLUMNS
+from app.domain.exceptions import ExcelProcessingError
+
+
+class DummyRepo:
+    def __init__(self):
+        self.inserted = []
+        self.updated = []
+
+    def get_by_ids(self, ids):
+        return []
+
+    def insert_many(self, tareas):
+        self.inserted.extend(tareas)
+
+    def update_one(self, tarea):
+        self.updated.append(tarea)
+
+
+class DummyFile:
+    file = "dummy.xlsx"
+
+
+def test_ejecutar_missing_columns(monkeypatch):
+    repo = DummyRepo()
+    use_case = ProcesarTareasUseCase(repo)
+
+    def fake_reader(file):
+        return [], [REQUIRED_COLUMNS[0]]
+
+    monkeypatch.setattr(
+        "app.domain.use_cases.procesar_tareas.read_excel_file", fake_reader
+    )
+
+    with pytest.raises(ExcelProcessingError):
+        use_case.ejecutar(DummyFile())
+
+
+def test_ejecutar_success(monkeypatch):
+    repo = DummyRepo()
+    use_case = ProcesarTareasUseCase(repo)
+
+    record = {col: f"val_{i}" for i, col in enumerate(REQUIRED_COLUMNS)}
+
+    def fake_reader(file):
+        return [record], REQUIRED_COLUMNS
+
+    def fake_comparator(tareas, existentes):
+        return tareas, []
+
+    monkeypatch.setattr(
+        "app.domain.use_cases.procesar_tareas.read_excel_file", fake_reader
+    )
+    monkeypatch.setattr(
+        "app.domain.use_cases.procesar_tareas.comparar_tareas", fake_comparator
+    )
+
+    result = use_case.ejecutar(DummyFile())
+
+    assert result == {"insertados": 1, "actualizados": 0}
+    assert len(repo.inserted) == 1
+    assert repo.updated == []


### PR DESCRIPTION
## Summary
- add pytest setup so backend modules can be imported
- test `ProcesarTareasUseCase.ejecutar` error handling for missing columns
- test successful processing flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867eab780f4832b82eac385841487f8